### PR TITLE
do not do conversions to float in interrupt callback and give access to ...

### DIFF
--- a/idDHTLib.h
+++ b/idDHTLib.h
@@ -31,7 +31,7 @@
 #include <WProgram.h>
 #endif
 
-#define IDDHTLIB_VERSION "0.0.3"
+#define IDDHTLIB_VERSION "0.0.4"
 
 // state codes
 #define IDDHTLIB_OK			0
@@ -69,9 +69,14 @@ public:
 	bool acquiring();
 	int getStatus();
 	
+	int getRawTemperature();
+	int getRawHumidity();
+	
 private:
 	
 	void (*isrCallback_wrapper)(void);
+	
+	bool isDHT22;
 	
 	enum states{RESPONSE=0,DATA=1,ACQUIRED=2,STOPPED=3,ACQUIRING=4};
 	volatile states state;
@@ -82,8 +87,8 @@ private:
 	volatile int us;
 	int intNumber;
 	int pin;
-	volatile float hum;
-	volatile float temp;
+	volatile int hum;
+	volatile int temp;
 	void isrCallback(bool dht22);
 };
 #endif // idDHTLib_H__

--- a/idDHTLib.h
+++ b/idDHTLib.h
@@ -68,7 +68,6 @@ public:
 	float getHumidity();
 	bool acquiring();
 	int getStatus();
-	
 	int getRawTemperature();
 	int getRawHumidity();
 	
@@ -76,8 +75,7 @@ private:
 	
 	void (*isrCallback_wrapper)(void);
 	
-	bool isDHT22;
-	
+	volatile bool isDHT22;
 	enum states{RESPONSE=0,DATA=1,ACQUIRED=2,STOPPED=3,ACQUIRING=4};
 	volatile states state;
 	volatile int status;


### PR DESCRIPTION
...raw integer data.

In some applications you do not want the float data (e.g. if you want to send the data on wireless and keep packets small), so access to integer based data is needed.
Also not converting the data in the interrupt callback but only when the data is queried is probably a performance improvement.

In any case, thanks for this library, it seems much more reliable that the blocking version from Adafruit.
