### PR TITLE
Moving to version 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,183 @@
-idDHTLib
-=======
+# idDHTLib
 
-Interrupt driven DHT11 & DHT22 library
+Interrupt driven DHT11 & DHT22 temperature and humidity sensor Arduino library.
 
-VERSION:	0.0.3
 
-PURPOSE:	Interrupt driven Lib for DHT11 and DHT22 with Arduino.
+## Usage
 
-LICENCE:	GPL v3 (http://www.gnu.org/licenses/gpl.html)
+#### Instantiate the sensor object
+```c++
+    // for DHT11
+    idDHTLib DHTLib(pinNumber);
+    
+     // for DHT11 and DHT22, sensorType can be idDHTLib::DHT11 or idDHTLib::DHT22
+    idDHTLib DHTLib(pinNumber, sensorType);
+```
 
-DATASHEET:	http://www.micro4you.com/files/sensor/DHT11.pdf
+*pinNumber* is the digital pin number from the Arduino board and must be an external interrupt capable pin
 
-DATASHEET:	http://www.adafruit.com/datasheets/DHT22.pdf
+<table class="rich-diff-level-zero">
+  <thead class="rich-diff-level-one">
+    <tr>
+      <th>Board</th>
+      <th>int.0</th>
+      <th>int.1</th>
+      <th>int.2</th>
+      <th>int.3</th>
+      <th>int.4</th>
+      <th>int.5</th>
+    </tr>
+  </thead>
+  <tbody class="rich-diff-level-one">
+    <tr>
+      <td>Uno, Ethernet</td>
+      <td align="center">2</td>
+      <td align="center">3</td>
+      <td align="center"></td>
+      <td align="center"></td>
+      <td align="center"></td>
+      <td align="center"></td>
+    </tr>
+    <tr>
+      <td>Mega2560</td>
+      <td align="center">2</td>
+      <td align="center">3</td>
+      <td align="center">21</td>
+      <td align="center">20</td>
+      <td align="center">19</td>
+      <td align="center">18</td>
+    </tr>
+    <tr>
+      <td>Leonardo</td>
+      <td align="center">3</td>
+      <td align="center">2</td>
+      <td align="center">0</td>
+      <td align="center">1</td>
+      <td align="center"></td>
+      <td align="center"></td>
+    </tr>
+    <tr>
+      <td>Due</td>
+      <td colspan="6">(any pin, more info <a href="http://arduino.cc/en/Reference/AttachInterrupt">http://arduino.cc/en/Reference/AttachInterrupt</a>)</td>
+    </tr>
+  </tbody>
+</table>
 
-Based on idDHT11 library:	https://github.com/niesteszeck/idDHT11
 
-Based on DHTLib library:	http://playground.arduino.cc/Main/DHTLib
+#### Start the reading
 
-Based on code proposed:		https://forum.arduino.cc/index.php?topic=175356.0
+The sensor reading can be started with one of these methods
+```c++
+//lasts about 18ms
+DHTLib.acquire();
 
-Changelog:
+//lasts a few uS but need the acquiring() function to be called at intervals < 10ms
+//this should be used in cases where the other tasks in the loop() have to respond fast
+DHTLib.acquireFastLoop();
 
-v 0.0.1
-* fork from idDHT11 lib
-* change names to idDHTLib
-* added DHT22 functionality
+//blocks the execution until the reading is complete
+DHTLib.acquireAndWait();
+```
 
-v 0.0.2
-* Optimization on shift var (pylon from Arduino Forum)
+#### Checking for completion
 
-v 0.0.3
-* Timing correction to finally work properly on DHT22 (Dessimat0r from Arduino forum)
+```c++
+DHTLib.acquiring() //returns false when reading is complete (or not started)
+```
 
-Thanks to Dessimat0r we finally can say that is ready, please try it and if you have some trouble I'll glad to accept changes that solve this problems.
+#### Checking for errors
+
+After the reading is complete
+```c++
+DHTLib.getStatus() 
+```
+* returns one of these values
+	* IDDHTLIB_OK - the reading was successful
+	* IDDHTLIB_ERROR_CHECKSUM
+	* IDDHTLIB_ERROR_TIMEOUT
+	* IDDHTLIB_ERROR_ACQUIRING
+	* IDDHTLIB_ERROR_DELTA
+	* IDDHTLIB_ERROR_NOTSTARTED
+
+
+#### Sensor data
+
+After the reading is complete and the status was `IDDHTLIB_OK`
+```c++
+DHTLib.getCelsius() // float 
+DHTLib.getFahrenheit() // float 
+DHTLib.getKelvin() // float 
+DHTLib.getDewPoint() // double, 5x faster than dewPointSlow(), delta max = 0.6544 wrt dewPointSlow()
+DHTLib.getDewPointSlow() // double
+DHTLib.getHumidity() // float 
+```
+
+
+## Basic example
+
+```c++
+idDHTLib DHTLib(2, idDHTLib::DHT11);
+
+void setup() {
+  Serial.begin(9600);
+}
+
+void loop() {
+  int result = DHTLib.acquireAndWait();
+  if (result == IDDHTLIB_OK) {
+    Serial.print("Humidity (%): ");
+    Serial.println(DHTLib.getHumidity(), 2);
+  
+    Serial.print("Temperature (oC): ");
+    Serial.println(DHTLib.getCelsius(), 2);
+  
+    Serial.print("Temperature (oF): ");
+    Serial.println(DHTLib.getFahrenheit(), 2);
+  
+    Serial.print("Temperature (K): ");
+    Serial.println(DHTLib.getKelvin(), 2);
+  
+    Serial.print("Dew Point (oC): ");
+    Serial.println(DHTLib.getDewPoint());
+  
+    Serial.print("Dew Point Slow (oC): ");
+    Serial.println(DHTLib.getDewPointSlow());
+  } else {
+    Serial.println("Error");
+  }
+  delay(2000);
+}
+```
+
+## Changelog
+* v 0.0.1
+	* fork from idDHT11 lib
+	* change names to idDHTLib
+	* added DHT22 functionality
+* v 0.0.2
+	* Optimization on shift var (pylon from Arduino Forum)
+* v 0.0.3
+	* Timing correction to finally work properly on DHT22 (Dessimat0r from Arduino forum)
+* v 1.0.0
+	* autoformat code with Arduino IDE code formatting standards (kcsoft)
+	* remove the interrupt number from the constructor by using digitalPinToInterrupt (kcsoft)
+	* fix type for us and timeout when no interrupt is triggered (kcsoft)
+	* removed the callback parameter from the constructor, added sensor type (DHT11, DHT22) as optional param (kcsoft)
+	* removed temp/humid calculation from the isr (kcsoft)
+	* new function acquireFastLoop to remove delay when start acquiring (kcsoft)
+	* update README.md file (kcsoft)
+
+
+## Datasheet
+[DHT11](http://www.micro4you.com/files/sensor/DHT11.pdf)  
+[DHT22](http://www.adafruit.com/datasheets/DHT22.pdf)
+
+
+## Based on
+[idDHT11 library](https://github.com/niesteszeck/idDHT11)  
+[DHTLib library](http://playground.arduino.cc/Main/DHTLib)  
+[Code proposed on Arduino forum](https://forum.arduino.cc/index.php?topic=175356.0)
+
+
+## License
+[GPL v3](http://www.gnu.org/licenses/gpl.html)

--- a/examples/idDHTLib_example/idDHTLib_example.ino
+++ b/examples/idDHTLib_example/idDHTLib_example.ino
@@ -10,11 +10,8 @@
 
 int idDHTLibPin = 2; //Digital pin for comunications
 
-//declaration
-void dhtLib_wrapper(); // must be declared before the lib initialization
-
 // Lib instantiate
-idDHTLib DHTLib(idDHTLibPin,dhtLib_wrapper);
+idDHTLib DHTLib(idDHTLibPin, idDHTLib::DHT11);
 
 void setup()
 {
@@ -25,11 +22,7 @@ void setup()
   Serial.println("---------------");
   delay(3000); // The sensor need like 2 sec to initialize, if you have some code before this that make a delay, you can eliminate this delay
 }
-// This wrapper is in charge of calling 
-// mus be defined like this for the lib work
-void dhtLib_wrapper() {
-  DHTLib.dht11Callback(); // Change dht11Callback() for a dht22Callback() if you have a DHT22 sensor
-}
+
 void loop()
 {
   Serial.print("\nRetrieving information from sensor: ");

--- a/examples/idDHTLib_example/idDHTLib_example.ino
+++ b/examples/idDHTLib_example/idDHTLib_example.ino
@@ -9,13 +9,12 @@
 #include <idDHTLib.h>
 
 int idDHTLibPin = 2; //Digital pin for comunications
-int idDHTLibIntNumber = 0; //interrupt number (must be the one that use the previus defined pin (see table above)
 
 //declaration
 void dhtLib_wrapper(); // must be declared before the lib initialization
 
 // Lib instantiate
-idDHTLib DHTLib(idDHTLibPin,idDHTLibIntNumber,dhtLib_wrapper);
+idDHTLib DHTLib(idDHTLibPin,dhtLib_wrapper);
 
 void setup()
 {

--- a/examples/idDHTLib_example_Simple/idDHTLib_example_Simple.ino
+++ b/examples/idDHTLib_example_Simple/idDHTLib_example_Simple.ino
@@ -11,13 +11,12 @@
 #include <idDHTLib.h>
 
 int idDHTLibPin = 2; //Digital pin for comunications
-int idDHTLibIntNumber = 0; //interrupt number (must be the one that use the previus defined pin (see table above)
 
 //declaration
 void dhtLib_wrapper(); // must be declared before the lib initialization
 
 // Lib instantiate
-idDHTLib DHTLib(idDHTLibPin,idDHTLibIntNumber,dhtLib_wrapper);
+idDHTLib DHTLib(idDHTLibPin,dhtLib_wrapper);
 
 void setup()
 {

--- a/examples/idDHTLib_example_Simple/idDHTLib_example_Simple.ino
+++ b/examples/idDHTLib_example_Simple/idDHTLib_example_Simple.ino
@@ -12,11 +12,8 @@
 
 int idDHTLibPin = 2; //Digital pin for comunications
 
-//declaration
-void dhtLib_wrapper(); // must be declared before the lib initialization
-
 // Lib instantiate
-idDHTLib DHTLib(idDHTLibPin,dhtLib_wrapper);
+idDHTLib DHTLib(idDHTLibPin);
 
 void setup()
 {
@@ -27,11 +24,7 @@ void setup()
   Serial.println("---------------");
   delay(3000); // The sensor need like 2 sec to initialize, if you have some code before this that make a delay, you can eliminate this delay
 }
-// This wrapper is in charge of calling 
-// mus be defined like this for the lib work
-void dhtLib_wrapper() {
-  DHTLib.dht11Callback(); // Change dht11Callback() for a dht22Callback() if you have a DHT22 sensor
-}
+
 void loop()
 {
   Serial.print("\nRetrieving information from sensor: ");

--- a/idDHTLib.cpp
+++ b/idDHTLib.cpp
@@ -20,6 +20,14 @@
 		v 0.0.3
 			Timing correction to finally work properly on DHT22
 			(Dessimat0r from Arduino forum)
+    v 1.0.0
+      autoformat code with Arduino IDE code formatting standards (kcsoft)
+      remove the interrupt number from the constructor by using digitalPinToInterrupt (kcsoft)
+      fix type for us and timeout when no interrupt is triggered (kcsoft)
+      removed the callback parameter from the constructor, added sensor type (DHT11, DHT22) as optional param (kcsoft)
+      removed temp/humid calculation from the isr (kcsoft)
+      new function acquireFastLoop to remove delay when start acquiring (kcsoft)
+      update README.md file (kcsoft)
  */
 
 #include "idDHTLib.h"

--- a/idDHTLib.cpp
+++ b/idDHTLib.cpp
@@ -25,12 +25,12 @@
 #include "idDHTLib.h"
 #define DEBUG_idDHTLIB
 
-idDHTLib::idDHTLib(int pin, int intNumber, void (*callback_wrapper)()) {
-  init(pin, intNumber, callback_wrapper);
+idDHTLib::idDHTLib(int pin, void (*callback_wrapper)()) {
+  init(pin, callback_wrapper);
 }
 
-void idDHTLib::init(int pin, int intNumber, void (*callback_wrapper) ()) {
-  this->intNumber = intNumber;
+void idDHTLib::init(int pin, void (*callback_wrapper) ()) {
+  this->intNumber = digitalPinToInterrupt(pin);
   this->pin = pin;
   this->isrCallback_wrapper = callback_wrapper;
   hum = 0;

--- a/idDHTLib.cpp
+++ b/idDHTLib.cpp
@@ -5,11 +5,11 @@
 	LICENCE:	GPL v3 (http://www.gnu.org/licenses/gpl.html)
 	DATASHEET: http://www.micro4you.com/files/sensor/DHT11.pdf
 	DATASHEET: http://www.adafruit.com/datasheets/DHT22.pdf
-	
+
 	Based on idDHT11 library: https://github.com/niesteszeck/idDHT11
 	Based on DHTLib library: http://playground.arduino.cc/Main/DHTLib
 	Based on code proposed: http://forum.arduino.cc/index.php?PHPSESSID=j6n105kl2h07nbj72ac4vbh4s5&topic=175356.0
-	
+
 	Changelog:
 		v 0.0.1
 			fork from idDHT11 lib
@@ -25,186 +25,186 @@
 #include "idDHTLib.h"
 #define DEBUG_idDHTLIB
 
-idDHTLib::idDHTLib(int pin, int intNumber,void (*callback_wrapper)()) {
-	init(pin, intNumber,callback_wrapper);
+idDHTLib::idDHTLib(int pin, int intNumber, void (*callback_wrapper)()) {
+  init(pin, intNumber, callback_wrapper);
 }
 
 void idDHTLib::init(int pin, int intNumber, void (*callback_wrapper) ()) {
-	this->intNumber = intNumber;
-	this->pin = pin;
-	this->isrCallback_wrapper = callback_wrapper;
-	hum = 0;
-	temp = 0;
-	pinMode(pin, OUTPUT);
-	digitalWrite(pin, HIGH);
-	state = STOPPED;
-	status = IDDHTLIB_ERROR_NOTSTARTED;
+  this->intNumber = intNumber;
+  this->pin = pin;
+  this->isrCallback_wrapper = callback_wrapper;
+  hum = 0;
+  temp = 0;
+  pinMode(pin, OUTPUT);
+  digitalWrite(pin, HIGH);
+  state = STOPPED;
+  status = IDDHTLIB_ERROR_NOTSTARTED;
 }
 
 int idDHTLib::acquire() {
-	if (state == STOPPED || state == ACQUIRED) {
-		
-		//set the state machine for interruptions analisis of the signal
-		state = RESPONSE;
-		
-		// EMPTY BUFFER and vars
-		for (int i=0; i< 5; i++) bits[i] = 0;
-		cnt = 7;
-		idx = 0;
-		hum = 0;
-		temp = 0;
-	
-		// REQUEST SAMPLE
-		pinMode(pin, OUTPUT);
-		digitalWrite(pin, LOW);
-		delay(18);
-		digitalWrite(pin, HIGH);
-		delayMicroseconds(25);
-		pinMode(pin, INPUT);
-		
-		// Analize the data in an interrupt
-		us = micros();
-		attachInterrupt(intNumber,isrCallback_wrapper,FALLING);
-		
-		return IDDHTLIB_ACQUIRING;
-	} else
-		return IDDHTLIB_ERROR_ACQUIRING;
+  if (state == STOPPED || state == ACQUIRED) {
+
+    //set the state machine for interruptions analisis of the signal
+    state = RESPONSE;
+
+    // EMPTY BUFFER and vars
+    for (int i = 0; i < 5; i++) bits[i] = 0;
+    cnt = 7;
+    idx = 0;
+    hum = 0;
+    temp = 0;
+
+    // REQUEST SAMPLE
+    pinMode(pin, OUTPUT);
+    digitalWrite(pin, LOW);
+    delay(18);
+    digitalWrite(pin, HIGH);
+    delayMicroseconds(25);
+    pinMode(pin, INPUT);
+
+    // Analize the data in an interrupt
+    us = micros();
+    attachInterrupt(intNumber, isrCallback_wrapper, FALLING);
+
+    return IDDHTLIB_ACQUIRING;
+  } else
+    return IDDHTLIB_ERROR_ACQUIRING;
 }
 int idDHTLib::acquireAndWait() {
-	acquire();
-	while(acquiring())
-		;
-	return getStatus();
+  acquire();
+  while (acquiring())
+    ;
+  return getStatus();
 }
 void idDHTLib::dht11Callback() {
-	isrCallback(false);
+  isrCallback(false);
 }
 void idDHTLib::dht22Callback() {
-	isrCallback(true);
+  isrCallback(true);
 }
 void idDHTLib::isrCallback(bool dht22) {
-	int newUs = micros();
-	int delta = (newUs-us);
-	us = newUs;
-	if (delta>6000) {
-		status = IDDHTLIB_ERROR_TIMEOUT;
-		state = STOPPED;
-		detachInterrupt(intNumber);
-		return;
-	}
-	switch(state) {
-		case RESPONSE:
-			if(delta<25){
-				us -= delta;
-				break; //do nothing, it started the response signal
-			} if(125<delta && delta<190) {
-				state = DATA;
-			} else {
-				detachInterrupt(intNumber);
-				status = IDDHTLIB_ERROR_TIMEOUT;
-				state = STOPPED;
-			}
-			break;
-		case DATA:
-			if(60<delta && delta<145) { //valid in timing
-				bits[idx] <<= 1; //shift the data
-				if(delta>100) //is a one
-					bits[idx] |= 1;
-				if (cnt == 0) {  // when we have fulfilled the byte, go to the next
-						cnt = 7;    // restart at MSB
-						if(++idx == 5) { // go to next byte; when we have got 5 bytes, stop.
-							detachInterrupt(intNumber);
-							// WRITE TO RIGHT VARS 
-							uint8_t sum;
-							if (dht22) {
-								hum = word(bits[0], bits[1]) * 0.1;
-								temp = (bits[2] & 0x80 ?
-									-word(bits[2] & 0x7F, bits[3]) :
-									word(bits[2], bits[3]))
-								* 0.1;
-								sum = bits[0] + bits[1] + bits[2] + bits[3];
-							} else {
-								hum    = bits[0]; 
-								// as bits[1] and bits[3] are always zero they are omitted in formulas.
-								temp = bits[2];
-								sum = bits[0] + bits[2];
-							}  
-							if (bits[4] != (sum&0xFF)) {
-								status = IDDHTLIB_ERROR_CHECKSUM;
-								state = STOPPED;
-							} else {
-								status = IDDHTLIB_OK;
-								state = ACQUIRED;
-							}
-							break;
-						}
-				} else cnt--;
-			} else if(delta<10) {
-				detachInterrupt(intNumber);
-				status = IDDHTLIB_ERROR_DELTA;
-				state = STOPPED;
-			} else {
-				detachInterrupt(intNumber);
-				status = IDDHTLIB_ERROR_TIMEOUT;
-				state = STOPPED;
-			}
-			break;
-		default:
-			break;
-	}
+  int newUs = micros();
+  int delta = (newUs - us);
+  us = newUs;
+  if (delta > 6000) {
+    status = IDDHTLIB_ERROR_TIMEOUT;
+    state = STOPPED;
+    detachInterrupt(intNumber);
+    return;
+  }
+  switch (state) {
+    case RESPONSE:
+      if (delta < 25) {
+        us -= delta;
+        break; //do nothing, it started the response signal
+      } if (125 < delta && delta < 190) {
+        state = DATA;
+      } else {
+        detachInterrupt(intNumber);
+        status = IDDHTLIB_ERROR_TIMEOUT;
+        state = STOPPED;
+      }
+      break;
+    case DATA:
+      if (60 < delta && delta < 145) { //valid in timing
+        bits[idx] <<= 1; //shift the data
+        if (delta > 100) //is a one
+          bits[idx] |= 1;
+        if (cnt == 0) {  // when we have fulfilled the byte, go to the next
+          cnt = 7;    // restart at MSB
+          if (++idx == 5) { // go to next byte; when we have got 5 bytes, stop.
+            detachInterrupt(intNumber);
+            // WRITE TO RIGHT VARS
+            uint8_t sum;
+            if (dht22) {
+              hum = word(bits[0], bits[1]) * 0.1;
+              temp = (bits[2] & 0x80 ?
+                      -word(bits[2] & 0x7F, bits[3]) :
+                      word(bits[2], bits[3]))
+                     * 0.1;
+              sum = bits[0] + bits[1] + bits[2] + bits[3];
+            } else {
+              hum    = bits[0];
+              // as bits[1] and bits[3] are always zero they are omitted in formulas.
+              temp = bits[2];
+              sum = bits[0] + bits[2];
+            }
+            if (bits[4] != (sum & 0xFF)) {
+              status = IDDHTLIB_ERROR_CHECKSUM;
+              state = STOPPED;
+            } else {
+              status = IDDHTLIB_OK;
+              state = ACQUIRED;
+            }
+            break;
+          }
+        } else cnt--;
+      } else if (delta < 10) {
+        detachInterrupt(intNumber);
+        status = IDDHTLIB_ERROR_DELTA;
+        state = STOPPED;
+      } else {
+        detachInterrupt(intNumber);
+        status = IDDHTLIB_ERROR_TIMEOUT;
+        state = STOPPED;
+      }
+      break;
+    default:
+      break;
+  }
 }
 bool idDHTLib::acquiring() {
-	if (state != ACQUIRED && state != STOPPED)
-		return true;
-	return false;
+  if (state != ACQUIRED && state != STOPPED)
+    return true;
+  return false;
 }
 int idDHTLib::getStatus() {
-	return status;
+  return status;
 }
 float idDHTLib::getCelsius() {
-	IDDHTLIB_CHECK_STATE;
-	return temp;
+  IDDHTLIB_CHECK_STATE;
+  return temp;
 }
 
 float idDHTLib::getHumidity() {
-	IDDHTLIB_CHECK_STATE;
-	return hum;
+  IDDHTLIB_CHECK_STATE;
+  return hum;
 }
 
 float idDHTLib::getFahrenheit() {
-	IDDHTLIB_CHECK_STATE;
-	return temp * 1.8 + 32;
+  IDDHTLIB_CHECK_STATE;
+  return temp * 1.8 + 32;
 }
 
 float idDHTLib::getKelvin() {
-	IDDHTLIB_CHECK_STATE;
-	return temp + 273.15;
+  IDDHTLIB_CHECK_STATE;
+  return temp + 273.15;
 }
 
 // delta max = 0.6544 wrt dewPoint()
 // 5x faster than dewPoint()
 // reference: http://en.wikipedia.org/wiki/Dew_point
 double idDHTLib::getDewPoint() {
-	IDDHTLIB_CHECK_STATE;
-	double a = 17.271;
-	double b = 237.7;
-	double temp_ = (a * (double) temp) / (b + (double) temp) + log( (double) hum/100);
-	double Td = (b * temp_) / (a - temp_);
-	return Td;
-	
+  IDDHTLIB_CHECK_STATE;
+  double a = 17.271;
+  double b = 237.7;
+  double temp_ = (a * (double) temp) / (b + (double) temp) + log( (double) hum / 100);
+  double Td = (b * temp_) / (a - temp_);
+  return Td;
+
 }
 // dewPoint function NOAA
-// reference: http://wahiduddin.net/calc/density_algorithms.htm 
+// reference: http://wahiduddin.net/calc/density_algorithms.htm
 double idDHTLib::getDewPointSlow() {
-	IDDHTLIB_CHECK_STATE;
-	double A0= 373.15/(273.15 + (double) temp);
-	double SUM = -7.90298 * (A0-1);
-	SUM += 5.02808 * log10(A0);
-	SUM += -1.3816e-7 * (pow(10, (11.344*(1-1/A0)))-1) ;
-	SUM += 8.1328e-3 * (pow(10,(-3.49149*(A0-1)))-1) ;
-	SUM += log10(1013.246);
-	double VP = pow(10, SUM-3) * (double) hum;
-	double T = log(VP/0.61078);   // temp var
-	return (241.88 * T) / (17.558-T);
+  IDDHTLIB_CHECK_STATE;
+  double A0 = 373.15 / (273.15 + (double) temp);
+  double SUM = -7.90298 * (A0 - 1);
+  SUM += 5.02808 * log10(A0);
+  SUM += -1.3816e-7 * (pow(10, (11.344 * (1 - 1 / A0))) - 1) ;
+  SUM += 8.1328e-3 * (pow(10, (-3.49149 * (A0 - 1))) - 1) ;
+  SUM += log10(1013.246);
+  double VP = pow(10, SUM - 3) * (double) hum;
+  double T = log(VP / 0.61078); // temp var
+  return (241.88 * T) / (17.558 - T);
 }
 // EOF

--- a/idDHTLib.h
+++ b/idDHTLib.h
@@ -10,16 +10,24 @@
 	Based on DHTLib library: http://playground.arduino.cc/Main/DHTLib
 	Based on code proposed: http://forum.arduino.cc/index.php?PHPSESSID=j6n105kl2h07nbj72ac4vbh4s5&topic=175356.0
 
-	Changelog:
-		v 0.0.1
-			fork from idDHT11 lib
-			change names to idDHTLib
-			added DHT22 functionality
-		v 0.0.2
-			Optimization on shift var (pylon from Arduino Forum)
-		v 0.0.3
-			Timing correction to finally work properly on DHT22
-			(Dessimat0r from Arduino forum)
+  Changelog:
+    v 0.0.1
+      fork from idDHT11 lib
+      change names to idDHTLib
+      added DHT22 functionality
+    v 0.0.2
+      Optimization on shift var (pylon from Arduino Forum)
+    v 0.0.3
+      Timing correction to finally work properly on DHT22
+      (Dessimat0r from Arduino forum)
+    v 1.0.0
+      autoformat code with Arduino IDE code formatting standards (kcsoft)
+      remove the interrupt number from the constructor by using digitalPinToInterrupt (kcsoft)
+      fix type for us and timeout when no interrupt is triggered (kcsoft)
+      removed the callback parameter from the constructor, added sensor type (DHT11, DHT22) as optional param (kcsoft)
+      removed temp/humid calculation from the isr (kcsoft)
+      new function acquireFastLoop to remove delay when start acquiring (kcsoft)
+      update README.md file (kcsoft)
  */
 
 #ifndef idDHTLib_H__
@@ -31,7 +39,7 @@
 #include <WProgram.h>
 #endif
 
-#define IDDHTLIB_VERSION "0.0.3"
+#define IDDHTLIB_VERSION "1.0.0"
 
 // state codes
 #define IDDHTLIB_OK			0

--- a/idDHTLib.h
+++ b/idDHTLib.h
@@ -5,11 +5,11 @@
 	LICENCE:	GPL v3 (http://www.gnu.org/licenses/gpl.html)
 	DATASHEET: http://www.micro4you.com/files/sensor/DHT11.pdf
 	DATASHEET: http://www.adafruit.com/datasheets/DHT22.pdf
-	
+
 	Based on idDHT11 library: https://github.com/niesteszeck/idDHT11
 	Based on DHTLib library: http://playground.arduino.cc/Main/DHTLib
 	Based on code proposed: http://forum.arduino.cc/index.php?PHPSESSID=j6n105kl2h07nbj72ac4vbh4s5&topic=175356.0
-	
+
 	Changelog:
 		v 0.0.1
 			fork from idDHT11 lib
@@ -47,43 +47,43 @@
 #define IDDHTLIB_ERROR_NOTSTARTED	-5
 
 #define IDDHTLIB_CHECK_STATE		if(state == STOPPED)			\
-						return status;			\
-					else if(state != ACQUIRED)		\
-						return IDDHTLIB_ERROR_ACQUIRING;
-									
+    return status;			\
+  else if(state != ACQUIRED)		\
+    return IDDHTLIB_ERROR_ACQUIRING;
+
 class idDHTLib
 {
-public:
-	idDHTLib(int pin, int intNumber,void (*isrCallback_wrapper)());
-    	void init(int pin, int intNumber,void (*isrCallback_wrapper)());
-	void dht11Callback();
-	void dht22Callback();
-	int acquire();
-	int acquireAndWait();
-	float getCelsius();
-	float getFahrenheit();
-	float getKelvin();
-	double getDewPoint();
-	double getDewPointSlow();
-	float getHumidity();
-	bool acquiring();
-	int getStatus();
-	
-private:
-	
-	void (*isrCallback_wrapper)(void);
-	
-	enum states{RESPONSE=0,DATA=1,ACQUIRED=2,STOPPED=3,ACQUIRING=4};
-	volatile states state;
-	volatile int status;
-	volatile byte bits[5];
-	volatile byte cnt;
-	volatile byte idx;
-	volatile int us;
-	int intNumber;
-	int pin;
-	volatile float hum;
-	volatile float temp;
-	void isrCallback(bool dht22);
+  public:
+    idDHTLib(int pin, int intNumber, void (*isrCallback_wrapper)());
+    void init(int pin, int intNumber, void (*isrCallback_wrapper)());
+    void dht11Callback();
+    void dht22Callback();
+    int acquire();
+    int acquireAndWait();
+    float getCelsius();
+    float getFahrenheit();
+    float getKelvin();
+    double getDewPoint();
+    double getDewPointSlow();
+    float getHumidity();
+    bool acquiring();
+    int getStatus();
+
+  private:
+
+    void (*isrCallback_wrapper)(void);
+
+    enum states {RESPONSE = 0, DATA = 1, ACQUIRED = 2, STOPPED = 3, ACQUIRING = 4};
+    volatile states state;
+    volatile int status;
+    volatile byte bits[5];
+    volatile byte cnt;
+    volatile byte idx;
+    volatile int us;
+    int intNumber;
+    int pin;
+    volatile float hum;
+    volatile float temp;
+    void isrCallback(bool dht22);
 };
 #endif // idDHTLib_H__

--- a/idDHTLib.h
+++ b/idDHTLib.h
@@ -62,6 +62,7 @@ class idDHTLib
     idDHTLib(int pin, DHTType sensorType);
     void init(int pin, DHTType sensorType);
     int acquire();
+    int acquireFastLoop();
     int acquireAndWait();
     float getCelsius();
     float getFahrenheit();
@@ -73,7 +74,7 @@ class idDHTLib
     int getStatus();
 
   private:
-    enum states {RESPONSE = 0, DATA = 1, ACQUIRED = 2, STOPPED = 3, ACQUIRING = 4, RAW_DATA_READY = 5};
+    enum states {RESPONSE = 0, DATA = 1, ACQUIRED = 2, STOPPED = 3, ACQUIRING = 4, RAW_DATA_READY = 5, START_SIGNAL = 6};
     volatile states state;
     volatile int status;
     volatile byte bits[5];
@@ -86,6 +87,7 @@ class idDHTLib
     volatile float hum;
     volatile float temp;
     void dhtCallback();
+    int startSignal(bool useDelay);
 
 #include "idDHTLib_cb.h"
     const static pCallback pCallbackArray[MAX_INTERRUPT + 1];

--- a/idDHTLib.h
+++ b/idDHTLib.h
@@ -51,13 +51,16 @@
   else if(state != ACQUIRED)		\
     return IDDHTLIB_ERROR_ACQUIRING;
 
+typedef void (*pCallback)();
+
 class idDHTLib
 {
   public:
-    idDHTLib(int pin, void (*isrCallback_wrapper)());
-    void init(int pin, void (*isrCallback_wrapper)());
-    void dht11Callback();
-    void dht22Callback();
+    enum DHTType {DHT11, DHT22};
+
+    idDHTLib(int pin);
+    idDHTLib(int pin, DHTType sensorType);
+    void init(int pin, DHTType sensorType);
     int acquire();
     int acquireAndWait();
     float getCelsius();
@@ -70,9 +73,6 @@ class idDHTLib
     int getStatus();
 
   private:
-
-    void (*isrCallback_wrapper)(void);
-
     enum states {RESPONSE = 0, DATA = 1, ACQUIRED = 2, STOPPED = 3, ACQUIRING = 4};
     volatile states state;
     volatile int status;
@@ -82,8 +82,13 @@ class idDHTLib
     volatile unsigned long us;
     int intNumber;
     int pin;
+    DHTType sensorType;
     volatile float hum;
     volatile float temp;
-    void isrCallback(bool dht22);
+    void dhtCallback();
+
+#include "idDHTLib_cb.h"
+    const static pCallback pCallbackArray[MAX_INTERRUPT + 1];
+    static idDHTLib * objectAtInt[MAX_INTERRUPT + 1];
 };
 #endif // idDHTLib_H__

--- a/idDHTLib.h
+++ b/idDHTLib.h
@@ -73,7 +73,7 @@ class idDHTLib
     int getStatus();
 
   private:
-    enum states {RESPONSE = 0, DATA = 1, ACQUIRED = 2, STOPPED = 3, ACQUIRING = 4};
+    enum states {RESPONSE = 0, DATA = 1, ACQUIRED = 2, STOPPED = 3, ACQUIRING = 4, RAW_DATA_READY = 5};
     volatile states state;
     volatile int status;
     volatile byte bits[5];

--- a/idDHTLib.h
+++ b/idDHTLib.h
@@ -54,8 +54,8 @@
 class idDHTLib
 {
   public:
-    idDHTLib(int pin, int intNumber, void (*isrCallback_wrapper)());
-    void init(int pin, int intNumber, void (*isrCallback_wrapper)());
+    idDHTLib(int pin, void (*isrCallback_wrapper)());
+    void init(int pin, void (*isrCallback_wrapper)());
     void dht11Callback();
     void dht22Callback();
     int acquire();

--- a/idDHTLib.h
+++ b/idDHTLib.h
@@ -79,7 +79,7 @@ class idDHTLib
     volatile byte bits[5];
     volatile byte cnt;
     volatile byte idx;
-    volatile int us;
+    volatile unsigned long us;
     int intNumber;
     int pin;
     volatile float hum;

--- a/idDHTLib_cb.h
+++ b/idDHTLib_cb.h
@@ -1,0 +1,162 @@
+
+#include "max_interrupt.h"
+
+#define PFUNC_CALLBACKS
+
+#define CREATE_CALLBACK(x) static void dhtCallback##x() { objectAtInt[x]->dhtCallback(); }
+
+#if MAX_INTERRUPT >= 0
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0
+  CREATE_CALLBACK(0);
+#endif
+
+#if MAX_INTERRUPT >= 1
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1
+  CREATE_CALLBACK(1);
+#endif
+
+#if MAX_INTERRUPT >= 2
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2
+  CREATE_CALLBACK(2);
+#endif
+
+#if MAX_INTERRUPT >= 3
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3
+  CREATE_CALLBACK(3);
+#endif
+
+#if MAX_INTERRUPT >= 4
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4
+  CREATE_CALLBACK(4);
+#endif
+
+#if MAX_INTERRUPT >= 5
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5
+  CREATE_CALLBACK(5);
+#endif
+
+#if MAX_INTERRUPT >= 6
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6
+  CREATE_CALLBACK(6);
+#endif
+
+#if MAX_INTERRUPT >= 7
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7
+  CREATE_CALLBACK(7);
+#endif
+
+#if MAX_INTERRUPT >= 8
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8
+  CREATE_CALLBACK(8);
+#endif
+
+#if MAX_INTERRUPT >= 9
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9
+  CREATE_CALLBACK(9);
+#endif
+
+#if MAX_INTERRUPT >= 10
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10
+  CREATE_CALLBACK(10);
+#endif
+
+#if MAX_INTERRUPT >= 11
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11
+  CREATE_CALLBACK(11);
+#endif
+
+#if MAX_INTERRUPT >= 12
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12
+  CREATE_CALLBACK(12);
+#endif
+
+#if MAX_INTERRUPT >= 13
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13
+  CREATE_CALLBACK(13);
+#endif
+
+#if MAX_INTERRUPT >= 14
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14
+  CREATE_CALLBACK(14);
+#endif
+
+#if MAX_INTERRUPT >= 15
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15
+  CREATE_CALLBACK(15);
+#endif
+
+#if MAX_INTERRUPT >= 16
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16
+  CREATE_CALLBACK(16);
+#endif
+
+#if MAX_INTERRUPT >= 17
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17
+  CREATE_CALLBACK(17);
+#endif
+
+#if MAX_INTERRUPT >= 18
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18
+  CREATE_CALLBACK(18);
+#endif
+
+#if MAX_INTERRUPT >= 19
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19
+  CREATE_CALLBACK(19);
+#endif
+
+#if MAX_INTERRUPT >= 20
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20
+  CREATE_CALLBACK(20);
+#endif
+
+#if MAX_INTERRUPT >= 21
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21
+  CREATE_CALLBACK(21);
+#endif
+
+#if MAX_INTERRUPT >= 22
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21, &idDHTLib::dhtCallback22
+  CREATE_CALLBACK(22);
+#endif
+
+#if MAX_INTERRUPT >= 23
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21, &idDHTLib::dhtCallback22, &idDHTLib::dhtCallback23
+  CREATE_CALLBACK(23);
+#endif
+
+#if MAX_INTERRUPT >= 24
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21, &idDHTLib::dhtCallback22, &idDHTLib::dhtCallback23, &idDHTLib::dhtCallback24
+  CREATE_CALLBACK(24);
+#endif
+
+#if MAX_INTERRUPT >= 25
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21, &idDHTLib::dhtCallback22, &idDHTLib::dhtCallback23, &idDHTLib::dhtCallback24, &idDHTLib::dhtCallback25
+  CREATE_CALLBACK(25);
+#endif
+
+#if MAX_INTERRUPT >= 26
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21, &idDHTLib::dhtCallback22, &idDHTLib::dhtCallback23, &idDHTLib::dhtCallback24, &idDHTLib::dhtCallback25, &idDHTLib::dhtCallback26
+  CREATE_CALLBACK(26);
+#endif
+
+#if MAX_INTERRUPT >= 27
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21, &idDHTLib::dhtCallback22, &idDHTLib::dhtCallback23, &idDHTLib::dhtCallback24, &idDHTLib::dhtCallback25, &idDHTLib::dhtCallback26, &idDHTLib::dhtCallback27
+  CREATE_CALLBACK(27);
+#endif
+
+#if MAX_INTERRUPT >= 28
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21, &idDHTLib::dhtCallback22, &idDHTLib::dhtCallback23, &idDHTLib::dhtCallback24, &idDHTLib::dhtCallback25, &idDHTLib::dhtCallback26, &idDHTLib::dhtCallback27, &idDHTLib::dhtCallback28
+  CREATE_CALLBACK(28);
+#endif
+
+#if MAX_INTERRUPT >= 29
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21, &idDHTLib::dhtCallback22, &idDHTLib::dhtCallback23, &idDHTLib::dhtCallback24, &idDHTLib::dhtCallback25, &idDHTLib::dhtCallback26, &idDHTLib::dhtCallback27, &idDHTLib::dhtCallback28, &idDHTLib::dhtCallback29
+  CREATE_CALLBACK(29);
+#endif
+
+#if MAX_INTERRUPT >= 30
+#define PFUNC_CALLBACKS &idDHTLib::dhtCallback0, &idDHTLib::dhtCallback1, &idDHTLib::dhtCallback2, &idDHTLib::dhtCallback3, &idDHTLib::dhtCallback4, &idDHTLib::dhtCallback5, &idDHTLib::dhtCallback6, &idDHTLib::dhtCallback7, &idDHTLib::dhtCallback8, &idDHTLib::dhtCallback9, &idDHTLib::dhtCallback10, &idDHTLib::dhtCallback11, &idDHTLib::dhtCallback12, &idDHTLib::dhtCallback13, &idDHTLib::dhtCallback14, &idDHTLib::dhtCallback15, &idDHTLib::dhtCallback16, &idDHTLib::dhtCallback17, &idDHTLib::dhtCallback18, &idDHTLib::dhtCallback19, &idDHTLib::dhtCallback20, &idDHTLib::dhtCallback21, &idDHTLib::dhtCallback22, &idDHTLib::dhtCallback23, &idDHTLib::dhtCallback24, &idDHTLib::dhtCallback25, &idDHTLib::dhtCallback26, &idDHTLib::dhtCallback27, &idDHTLib::dhtCallback28, &idDHTLib::dhtCallback29, &idDHTLib::dhtCallback30
+  CREATE_CALLBACK(30);
+#endif
+

--- a/keywords.txt
+++ b/keywords.txt
@@ -21,8 +21,6 @@ getDewPointSlow	KEYWORD2
 getHumidity	KEYWORD2
 acquiring	KEYWORD2
 getStatus	KEYWORD2
-dht11Callback	KEYWORD2
-dht22Callback	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################

--- a/max_interrupt.h
+++ b/max_interrupt.h
@@ -1,0 +1,403 @@
+
+#define MAX_INTERRUPT  -1
+
+#if (digitalPinToInterrupt(1) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(1))
+#define MAX_INTERRUPT digitalPinToInterrupt(1)
+#endif
+
+#if (digitalPinToInterrupt(2) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(2))
+#define MAX_INTERRUPT digitalPinToInterrupt(2)
+#endif
+
+#if (digitalPinToInterrupt(3) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(3))
+#define MAX_INTERRUPT digitalPinToInterrupt(3)
+#endif
+
+#if (digitalPinToInterrupt(4) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(4))
+#define MAX_INTERRUPT digitalPinToInterrupt(4)
+#endif
+
+#if (digitalPinToInterrupt(5) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(5))
+#define MAX_INTERRUPT digitalPinToInterrupt(5)
+#endif
+
+#if (digitalPinToInterrupt(6) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(6))
+#define MAX_INTERRUPT digitalPinToInterrupt(6)
+#endif
+
+#if (digitalPinToInterrupt(7) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(7))
+#define MAX_INTERRUPT digitalPinToInterrupt(7)
+#endif
+
+#if (digitalPinToInterrupt(8) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(8))
+#define MAX_INTERRUPT digitalPinToInterrupt(8)
+#endif
+
+#if (digitalPinToInterrupt(9) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(9))
+#define MAX_INTERRUPT digitalPinToInterrupt(9)
+#endif
+
+#if (digitalPinToInterrupt(10) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(10))
+#define MAX_INTERRUPT digitalPinToInterrupt(10)
+#endif
+
+#if (digitalPinToInterrupt(11) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(11))
+#define MAX_INTERRUPT digitalPinToInterrupt(11)
+#endif
+
+#if (digitalPinToInterrupt(12) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(12))
+#define MAX_INTERRUPT digitalPinToInterrupt(12)
+#endif
+
+#if (digitalPinToInterrupt(13) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(13))
+#define MAX_INTERRUPT digitalPinToInterrupt(13)
+#endif
+
+#if (digitalPinToInterrupt(14) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(14))
+#define MAX_INTERRUPT digitalPinToInterrupt(14)
+#endif
+
+#if (digitalPinToInterrupt(15) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(15))
+#define MAX_INTERRUPT digitalPinToInterrupt(15)
+#endif
+
+#if (digitalPinToInterrupt(16) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(16))
+#define MAX_INTERRUPT digitalPinToInterrupt(16)
+#endif
+
+#if (digitalPinToInterrupt(17) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(17))
+#define MAX_INTERRUPT digitalPinToInterrupt(17)
+#endif
+
+#if (digitalPinToInterrupt(18) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(18))
+#define MAX_INTERRUPT digitalPinToInterrupt(18)
+#endif
+
+#if (digitalPinToInterrupt(19) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(19))
+#define MAX_INTERRUPT digitalPinToInterrupt(19)
+#endif
+
+#if (digitalPinToInterrupt(20) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(20))
+#define MAX_INTERRUPT digitalPinToInterrupt(20)
+#endif
+
+#if (digitalPinToInterrupt(21) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(21))
+#define MAX_INTERRUPT digitalPinToInterrupt(21)
+#endif
+
+#if (digitalPinToInterrupt(22) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(22))
+#define MAX_INTERRUPT digitalPinToInterrupt(22)
+#endif
+
+#if (digitalPinToInterrupt(23) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(23))
+#define MAX_INTERRUPT digitalPinToInterrupt(23)
+#endif
+
+#if (digitalPinToInterrupt(24) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(24))
+#define MAX_INTERRUPT digitalPinToInterrupt(24)
+#endif
+
+#if (digitalPinToInterrupt(25) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(25))
+#define MAX_INTERRUPT digitalPinToInterrupt(25)
+#endif
+
+#if (digitalPinToInterrupt(26) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(26))
+#define MAX_INTERRUPT digitalPinToInterrupt(26)
+#endif
+
+#if (digitalPinToInterrupt(27) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(27))
+#define MAX_INTERRUPT digitalPinToInterrupt(27)
+#endif
+
+#if (digitalPinToInterrupt(28) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(28))
+#define MAX_INTERRUPT digitalPinToInterrupt(28)
+#endif
+
+#if (digitalPinToInterrupt(29) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(29))
+#define MAX_INTERRUPT digitalPinToInterrupt(29)
+#endif
+
+#if (digitalPinToInterrupt(30) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(30))
+#define MAX_INTERRUPT digitalPinToInterrupt(30)
+#endif
+
+#if (digitalPinToInterrupt(31) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(31))
+#define MAX_INTERRUPT digitalPinToInterrupt(31)
+#endif
+
+#if (digitalPinToInterrupt(32) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(32))
+#define MAX_INTERRUPT digitalPinToInterrupt(32)
+#endif
+
+#if (digitalPinToInterrupt(33) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(33))
+#define MAX_INTERRUPT digitalPinToInterrupt(33)
+#endif
+
+#if (digitalPinToInterrupt(34) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(34))
+#define MAX_INTERRUPT digitalPinToInterrupt(34)
+#endif
+
+#if (digitalPinToInterrupt(35) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(35))
+#define MAX_INTERRUPT digitalPinToInterrupt(35)
+#endif
+
+#if (digitalPinToInterrupt(36) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(36))
+#define MAX_INTERRUPT digitalPinToInterrupt(36)
+#endif
+
+#if (digitalPinToInterrupt(37) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(37))
+#define MAX_INTERRUPT digitalPinToInterrupt(37)
+#endif
+
+#if (digitalPinToInterrupt(38) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(38))
+#define MAX_INTERRUPT digitalPinToInterrupt(38)
+#endif
+
+#if (digitalPinToInterrupt(39) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(39))
+#define MAX_INTERRUPT digitalPinToInterrupt(39)
+#endif
+
+#if (digitalPinToInterrupt(40) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(40))
+#define MAX_INTERRUPT digitalPinToInterrupt(40)
+#endif
+
+#if (digitalPinToInterrupt(41) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(41))
+#define MAX_INTERRUPT digitalPinToInterrupt(41)
+#endif
+
+#if (digitalPinToInterrupt(42) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(42))
+#define MAX_INTERRUPT digitalPinToInterrupt(42)
+#endif
+
+#if (digitalPinToInterrupt(43) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(43))
+#define MAX_INTERRUPT digitalPinToInterrupt(43)
+#endif
+
+#if (digitalPinToInterrupt(44) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(44))
+#define MAX_INTERRUPT digitalPinToInterrupt(44)
+#endif
+
+#if (digitalPinToInterrupt(45) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(45))
+#define MAX_INTERRUPT digitalPinToInterrupt(45)
+#endif
+
+#if (digitalPinToInterrupt(46) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(46))
+#define MAX_INTERRUPT digitalPinToInterrupt(46)
+#endif
+
+#if (digitalPinToInterrupt(47) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(47))
+#define MAX_INTERRUPT digitalPinToInterrupt(47)
+#endif
+
+#if (digitalPinToInterrupt(48) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(48))
+#define MAX_INTERRUPT digitalPinToInterrupt(48)
+#endif
+
+#if (digitalPinToInterrupt(49) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(49))
+#define MAX_INTERRUPT digitalPinToInterrupt(49)
+#endif
+
+#if (digitalPinToInterrupt(50) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(50))
+#define MAX_INTERRUPT digitalPinToInterrupt(50)
+#endif
+
+#if (digitalPinToInterrupt(51) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(51))
+#define MAX_INTERRUPT digitalPinToInterrupt(51)
+#endif
+
+#if (digitalPinToInterrupt(52) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(52))
+#define MAX_INTERRUPT digitalPinToInterrupt(52)
+#endif
+
+#if (digitalPinToInterrupt(53) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(53))
+#define MAX_INTERRUPT digitalPinToInterrupt(53)
+#endif
+
+#if (digitalPinToInterrupt(54) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(54))
+#define MAX_INTERRUPT digitalPinToInterrupt(54)
+#endif
+
+#if (digitalPinToInterrupt(55) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(55))
+#define MAX_INTERRUPT digitalPinToInterrupt(55)
+#endif
+
+#if (digitalPinToInterrupt(56) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(56))
+#define MAX_INTERRUPT digitalPinToInterrupt(56)
+#endif
+
+#if (digitalPinToInterrupt(57) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(57))
+#define MAX_INTERRUPT digitalPinToInterrupt(57)
+#endif
+
+#if (digitalPinToInterrupt(58) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(58))
+#define MAX_INTERRUPT digitalPinToInterrupt(58)
+#endif
+
+#if (digitalPinToInterrupt(59) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(59))
+#define MAX_INTERRUPT digitalPinToInterrupt(59)
+#endif
+
+#if (digitalPinToInterrupt(60) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(60))
+#define MAX_INTERRUPT digitalPinToInterrupt(60)
+#endif
+
+#if (digitalPinToInterrupt(61) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(61))
+#define MAX_INTERRUPT digitalPinToInterrupt(61)
+#endif
+
+#if (digitalPinToInterrupt(62) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(62))
+#define MAX_INTERRUPT digitalPinToInterrupt(62)
+#endif
+
+#if (digitalPinToInterrupt(63) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(63))
+#define MAX_INTERRUPT digitalPinToInterrupt(63)
+#endif
+
+#if (digitalPinToInterrupt(64) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(64))
+#define MAX_INTERRUPT digitalPinToInterrupt(64)
+#endif
+
+#if (digitalPinToInterrupt(65) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(65))
+#define MAX_INTERRUPT digitalPinToInterrupt(65)
+#endif
+
+#if (digitalPinToInterrupt(66) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(66))
+#define MAX_INTERRUPT digitalPinToInterrupt(66)
+#endif
+
+#if (digitalPinToInterrupt(67) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(67))
+#define MAX_INTERRUPT digitalPinToInterrupt(67)
+#endif
+
+#if (digitalPinToInterrupt(68) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(68))
+#define MAX_INTERRUPT digitalPinToInterrupt(68)
+#endif
+
+#if (digitalPinToInterrupt(69) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(69))
+#define MAX_INTERRUPT digitalPinToInterrupt(69)
+#endif
+
+#if (digitalPinToInterrupt(70) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(70))
+#define MAX_INTERRUPT digitalPinToInterrupt(70)
+#endif
+
+#if (digitalPinToInterrupt(71) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(71))
+#define MAX_INTERRUPT digitalPinToInterrupt(71)
+#endif
+
+#if (digitalPinToInterrupt(72) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(72))
+#define MAX_INTERRUPT digitalPinToInterrupt(72)
+#endif
+
+#if (digitalPinToInterrupt(73) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(73))
+#define MAX_INTERRUPT digitalPinToInterrupt(73)
+#endif
+
+#if (digitalPinToInterrupt(74) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(74))
+#define MAX_INTERRUPT digitalPinToInterrupt(74)
+#endif
+
+#if (digitalPinToInterrupt(75) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(75))
+#define MAX_INTERRUPT digitalPinToInterrupt(75)
+#endif
+
+#if (digitalPinToInterrupt(76) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(76))
+#define MAX_INTERRUPT digitalPinToInterrupt(76)
+#endif
+
+#if (digitalPinToInterrupt(77) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(77))
+#define MAX_INTERRUPT digitalPinToInterrupt(77)
+#endif
+
+#if (digitalPinToInterrupt(78) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(78))
+#define MAX_INTERRUPT digitalPinToInterrupt(78)
+#endif
+
+#if (digitalPinToInterrupt(79) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(79))
+#define MAX_INTERRUPT digitalPinToInterrupt(79)
+#endif
+
+#if (digitalPinToInterrupt(80) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(80))
+#define MAX_INTERRUPT digitalPinToInterrupt(80)
+#endif
+
+#if (digitalPinToInterrupt(81) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(81))
+#define MAX_INTERRUPT digitalPinToInterrupt(81)
+#endif
+
+#if (digitalPinToInterrupt(82) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(82))
+#define MAX_INTERRUPT digitalPinToInterrupt(82)
+#endif
+
+#if (digitalPinToInterrupt(83) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(83))
+#define MAX_INTERRUPT digitalPinToInterrupt(83)
+#endif
+
+#if (digitalPinToInterrupt(84) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(84))
+#define MAX_INTERRUPT digitalPinToInterrupt(84)
+#endif
+
+#if (digitalPinToInterrupt(85) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(85))
+#define MAX_INTERRUPT digitalPinToInterrupt(85)
+#endif
+
+#if (digitalPinToInterrupt(86) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(86))
+#define MAX_INTERRUPT digitalPinToInterrupt(86)
+#endif
+
+#if (digitalPinToInterrupt(87) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(87))
+#define MAX_INTERRUPT digitalPinToInterrupt(87)
+#endif
+
+#if (digitalPinToInterrupt(88) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(88))
+#define MAX_INTERRUPT digitalPinToInterrupt(88)
+#endif
+
+#if (digitalPinToInterrupt(89) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(89))
+#define MAX_INTERRUPT digitalPinToInterrupt(89)
+#endif
+
+#if (digitalPinToInterrupt(90) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(90))
+#define MAX_INTERRUPT digitalPinToInterrupt(90)
+#endif
+
+#if (digitalPinToInterrupt(91) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(91))
+#define MAX_INTERRUPT digitalPinToInterrupt(91)
+#endif
+
+#if (digitalPinToInterrupt(92) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(92))
+#define MAX_INTERRUPT digitalPinToInterrupt(92)
+#endif
+
+#if (digitalPinToInterrupt(93) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(93))
+#define MAX_INTERRUPT digitalPinToInterrupt(93)
+#endif
+
+#if (digitalPinToInterrupt(94) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(94))
+#define MAX_INTERRUPT digitalPinToInterrupt(94)
+#endif
+
+#if (digitalPinToInterrupt(95) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(95))
+#define MAX_INTERRUPT digitalPinToInterrupt(95)
+#endif
+
+#if (digitalPinToInterrupt(96) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(96))
+#define MAX_INTERRUPT digitalPinToInterrupt(96)
+#endif
+
+#if (digitalPinToInterrupt(97) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(97))
+#define MAX_INTERRUPT digitalPinToInterrupt(97)
+#endif
+
+#if (digitalPinToInterrupt(98) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(98))
+#define MAX_INTERRUPT digitalPinToInterrupt(98)
+#endif
+
+#if (digitalPinToInterrupt(99) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(99))
+#define MAX_INTERRUPT digitalPinToInterrupt(99)
+#endif
+
+#if (digitalPinToInterrupt(100) != NOT_AN_INTERRUPT) && (MAX_INTERRUPT < digitalPinToInterrupt(100))
+#define MAX_INTERRUPT digitalPinToInterrupt(100)
+#endif
+


### PR DESCRIPTION
The request includes all these commits, also note that the constructor for v1.0 is not compatible with v0.3 but we could create a constructor overload for that.

```
* autoformat code with Arduino IDE code formatting standards (kcsoft)
* remove the interrupt number from the constructor by using digitalPinToInterrupt (kcsoft)
* fix type for us and timeout when no interrupt is triggered (kcsoft)
* removed the callback parameter from the constructor, added sensor type (DHT11, DHT22) as optional param (kcsoft)
* removed temp/humid calculation from the isr (kcsoft)
* new function acquireFastLoop to remove delay when start acquiring (kcsoft)
* update README.md file (kcsoft)
```
